### PR TITLE
csp headers was sent multiply because we had push headers from nextjs…

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -26,3 +26,4 @@ npx playwright test tests/*.spec.ts
 **Note:**
 - Do not commit `storageState.json` to version control (it is in `.gitignore`).
 - Only run the login script when you need to refresh your authentication state.
+- Remember to set csp to dev, off or report-only


### PR DESCRIPTION
… - its fixed now so that headers only sent single. We also added csp settings instructions for playwright tests