### PR TITLE
implement infinite scroll with hierarchical pagination

### DIFF
--- a/src/app/TodoPageClient.tsx
+++ b/src/app/TodoPageClient.tsx
@@ -19,6 +19,7 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
   const [pageSize, setPageSize] = useState<number>(50);
   const [offset, setOffset] = useState<number>(initialTodos.length);
   const [hasMore, setHasMore] = useState<boolean>(true);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
   const { userId } = useUserId();
   const { runBlockingFetch } = useGlobalBlockingLoader();
@@ -28,6 +29,8 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
   const offsetRef = useRef<number>(offset);
   const pageSizeRef = useRef<number>(pageSize);
   const hasMoreRef = useRef<boolean>(hasMore);
+  const isRefreshingRef = useRef<boolean>(false);
+  const refreshSeqRef = useRef<number>(0);
   const selectedCategoryIdRef = useRef<string | null>(selectedCategory?.id ?? null);
 
   useEffect(() => {
@@ -43,11 +46,15 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
   }, [hasMore]);
 
   useEffect(() => {
+    isRefreshingRef.current = isRefreshing;
+  }, [isRefreshing]);
+
+  useEffect(() => {
     selectedCategoryIdRef.current = selectedCategory?.id ?? null;
   }, [selectedCategory]);
 
   const loadMore = useCallback(async () => {
-    if (!userId || !hasMoreRef.current || isLoadingMoreRef.current) return;
+    if (!userId || isRefreshingRef.current || !hasMoreRef.current || isLoadingMoreRef.current) return;
 
     const categoryId = selectedCategoryIdRef.current;
     const currentOffset = offsetRef.current;
@@ -99,9 +106,15 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
 
   useEffect(() => {
     if (!userId) return;
+    const currentRefreshSeq = ++refreshSeqRef.current;
+
     inFlightRequestKeysRef.current.clear();
     isLoadingMoreRef.current = false;
     setIsLoadingMore(false);
+    setIsRefreshing(true);
+    // Reset paging before category refresh to avoid stale offsets during in-flight loads.
+    setOffset(0);
+    setHasMore(true);
 
     let url = "/api/todos";
     if (selectedCategory && selectedCategory.id) {
@@ -119,6 +132,9 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
         return data;
       })
       .then((data) => {
+        if (refreshSeqRef.current !== currentRefreshSeq) {
+          return;
+        }
         setTodos(data.todos);
         setPageSize((prev) => (prev === data.limit ? prev : data.limit));
         setOffset(data.todos.length);
@@ -128,10 +144,17 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
         if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
+      })
+      .finally(() => {
+        if (refreshSeqRef.current === currentRefreshSeq) {
+          setIsRefreshing(false);
+        }
       });
   }, [selectedCategory, userId, runBlockingFetch]);
 
   useEffect(() => {
+    if (isRefreshing) return;
+
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
@@ -146,7 +169,7 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [loadMore]);
+  }, [loadMore, isRefreshing]);
 
   return (
     <>
@@ -155,7 +178,7 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
       </div>
       <TodoList initialTodos={todos} selectedCategory={selectedCategory} />
       <div ref={sentinelRef} className="py-4 text-center text-sm text-gray-600">
-        {isLoadingMore ? "Loading more todos..." : !hasMore ? "All todos loaded" : ""}
+        {isRefreshing ? "Loading todos..." : isLoadingMore ? "Loading more todos..." : !hasMore ? "All todos loaded" : ""}
       </div>
     </>
   );

--- a/src/app/TodoPageClient.tsx
+++ b/src/app/TodoPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import TodoList from "../components/TodoList";
 import CategoryDropdownWrapper from "../components/CategoryDropdownWrapper";
 import { useUserId } from "../context/UserIdContext";
@@ -8,11 +8,54 @@ import { Todo } from "../../types";
 import type { Category } from "../lib/categoryService";
 import { useGlobalBlockingLoader } from "../context/GlobalBlockingLoaderContext";
 
+type TodosResponse = {
+  todos: Todo[];
+  limit: number;
+};
+
 export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] }) {
   const [todos, setTodos] = useState<Todo[]>(initialTodos);
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+  const [pageSize, setPageSize] = useState<number>(50);
+  const [offset, setOffset] = useState<number>(initialTodos.length);
+  const [hasMore, setHasMore] = useState<boolean>(true);
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
   const { userId } = useUserId();
   const { runBlockingFetch } = useGlobalBlockingLoader();
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (!userId || !hasMore || isLoadingMore) return;
+    setIsLoadingMore(true);
+
+    try {
+      const params = new URLSearchParams({
+        offset: String(offset),
+        limit: String(pageSize),
+      });
+
+      if (selectedCategory?.id) {
+        params.set("category_id", selectedCategory.id);
+      }
+
+      const res = await fetch(`/api/todos?${params.toString()}`, {
+        method: "GET",
+        cache: "no-store",
+      });
+      if (!res.ok) {
+        throw new Error("Failed to load more todos");
+      }
+
+      const data: TodosResponse = await res.json();
+      setTodos((prev) => [...prev, ...data.todos]);
+      setOffset((prev) => prev + data.todos.length);
+      setHasMore(data.todos.length >= pageSize);
+    } catch {
+      setHasMore(false);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [userId, hasMore, isLoadingMore, offset, pageSize, selectedCategory]);
 
   useEffect(() => {
     if (!userId) return;
@@ -24,14 +67,42 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
       label: "Loading todos...",
       cancellable: true,
     })
-      .then((res) => (res.ok ? res.json() : []))
-      .then(setTodos)
+      .then(async (res) => {
+        if (!res.ok) {
+          return { todos: [], limit: pageSize } as TodosResponse;
+        }
+        const data = (await res.json()) as TodosResponse;
+        return data;
+      })
+      .then((data) => {
+        setTodos(data.todos);
+        setPageSize(data.limit);
+        setOffset(data.todos.length);
+        setHasMore(data.todos.length >= data.limit);
+      })
       .catch((error) => {
         if (error instanceof DOMException && error.name === "AbortError") {
           return;
         }
       });
-  }, [selectedCategory, userId, runBlockingFetch]);
+  }, [selectedCategory, userId, runBlockingFetch, pageSize]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          void loadMore();
+        }
+      },
+      { root: null, rootMargin: "200px 0px", threshold: 0 }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore]);
 
   return (
     <>
@@ -39,6 +110,9 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
         <CategoryDropdownWrapper onCategoryChange={setSelectedCategory} />
       </div>
       <TodoList initialTodos={todos} selectedCategory={selectedCategory} />
+      <div ref={sentinelRef} className="py-4 text-center text-sm text-gray-600">
+        {isLoadingMore ? "Loading more todos..." : !hasMore ? "All todos loaded" : ""}
+      </div>
     </>
   );
 }

--- a/src/app/TodoPageClient.tsx
+++ b/src/app/TodoPageClient.tsx
@@ -113,14 +113,14 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
     })
       .then(async (res) => {
         if (!res.ok) {
-          return { todos: [], limit: pageSize } as TodosResponse;
+          return { todos: [], limit: pageSizeRef.current } as TodosResponse;
         }
         const data = (await res.json()) as TodosResponse;
         return data;
       })
       .then((data) => {
         setTodos(data.todos);
-        setPageSize(data.limit);
+        setPageSize((prev) => (prev === data.limit ? prev : data.limit));
         setOffset(data.todos.length);
         setHasMore(data.todos.length >= data.limit);
       })
@@ -129,7 +129,7 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
           return;
         }
       });
-  }, [selectedCategory, userId, runBlockingFetch, pageSize]);
+  }, [selectedCategory, userId, runBlockingFetch]);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;

--- a/src/app/TodoPageClient.tsx
+++ b/src/app/TodoPageClient.tsx
@@ -23,19 +23,50 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
   const { userId } = useUserId();
   const { runBlockingFetch } = useGlobalBlockingLoader();
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const isLoadingMoreRef = useRef<boolean>(false);
+  const inFlightRequestKeysRef = useRef<Set<string>>(new Set());
+  const offsetRef = useRef<number>(offset);
+  const pageSizeRef = useRef<number>(pageSize);
+  const hasMoreRef = useRef<boolean>(hasMore);
+  const selectedCategoryIdRef = useRef<string | null>(selectedCategory?.id ?? null);
+
+  useEffect(() => {
+    offsetRef.current = offset;
+  }, [offset]);
+
+  useEffect(() => {
+    pageSizeRef.current = pageSize;
+  }, [pageSize]);
+
+  useEffect(() => {
+    hasMoreRef.current = hasMore;
+  }, [hasMore]);
+
+  useEffect(() => {
+    selectedCategoryIdRef.current = selectedCategory?.id ?? null;
+  }, [selectedCategory]);
 
   const loadMore = useCallback(async () => {
-    if (!userId || !hasMore || isLoadingMore) return;
+    if (!userId || !hasMoreRef.current || isLoadingMoreRef.current) return;
+
+    const categoryId = selectedCategoryIdRef.current;
+    const currentOffset = offsetRef.current;
+    const currentPageSize = pageSizeRef.current;
+    const requestKey = `${categoryId ?? "all"}:${currentOffset}:${currentPageSize}`;
+    if (inFlightRequestKeysRef.current.has(requestKey)) return;
+
+    inFlightRequestKeysRef.current.add(requestKey);
+    isLoadingMoreRef.current = true;
     setIsLoadingMore(true);
 
     try {
       const params = new URLSearchParams({
-        offset: String(offset),
-        limit: String(pageSize),
+        offset: String(currentOffset),
+        limit: String(currentPageSize),
       });
 
-      if (selectedCategory?.id) {
-        params.set("category_id", selectedCategory.id);
+      if (categoryId) {
+        params.set("category_id", categoryId);
       }
 
       const res = await fetch(`/api/todos?${params.toString()}`, {
@@ -47,18 +78,31 @@ export default function TodoPageClient({ initialTodos }: { initialTodos: Todo[] 
       }
 
       const data: TodosResponse = await res.json();
+      if (selectedCategoryIdRef.current !== categoryId) {
+        return;
+      }
+      if (offsetRef.current !== currentOffset) {
+        return;
+      }
+
       setTodos((prev) => [...prev, ...data.todos]);
       setOffset((prev) => prev + data.todos.length);
-      setHasMore(data.todos.length >= pageSize);
+      setHasMore(data.todos.length >= currentPageSize);
     } catch {
       setHasMore(false);
     } finally {
+      inFlightRequestKeysRef.current.delete(requestKey);
+      isLoadingMoreRef.current = false;
       setIsLoadingMore(false);
     }
-  }, [userId, hasMore, isLoadingMore, offset, pageSize, selectedCategory]);
+  }, [userId]);
 
   useEffect(() => {
     if (!userId) return;
+    inFlightRequestKeysRef.current.clear();
+    isLoadingMoreRef.current = false;
+    setIsLoadingMore(false);
+
     let url = "/api/todos";
     if (selectedCategory && selectedCategory.id) {
       url += `?category_id=${selectedCategory.id}`;

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -8,6 +8,7 @@ export async function GET(req: NextRequest) {
   const showCompleted = url.searchParams.get('showCompleted');
   const category_id = url.searchParams.get('category_id');
   const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
   // Default to true if not provided
   const showCompletedBool = showCompleted === null ? true : showCompleted === 'true';
   // Resolve the admin-controlled load policy and compute the effective limit.
@@ -16,10 +17,12 @@ export async function GET(req: NextRequest) {
   const policy = await getTodoLoadPolicy();
   const requestedLimit = limitParam !== null ? parseInt(limitParam, 10) : null;
   const effectiveLimit = computeEffectiveLimit(policy, requestedLimit);
+  const requestedOffset = offsetParam !== null ? parseInt(offsetParam, 10) : 0;
+  const effectiveOffset = Number.isFinite(requestedOffset) ? Math.max(requestedOffset, 0) : 0;
   // Import getTodos dynamically to avoid circular imports
   const { getTodos } = await import('../../../lib/dataService');
-  const todos = await getTodos(showCompletedBool, category_id, effectiveLimit);
-  return NextResponse.json(todos);
+  const todos = await getTodos(showCompletedBool, category_id, effectiveLimit, effectiveOffset);
+  return NextResponse.json({ todos, limit: effectiveLimit });
 }
 import { NextRequest, NextResponse } from 'next/server';
 import { createTodo, updateTodo } from '../../../lib/dataService';

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -462,7 +462,7 @@ export default function TodoList({ initialTodos, selectedCategory }: TodoListPro
       );
       if (!response.ok) throw new Error('Failed to fetch todos');
       const data = await response.json();
-      setTodos(data);
+      setTodos(Array.isArray(data) ? data : data.todos ?? []);
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         return;

--- a/src/integration-tests/Todos_sort_limit.integration.test.ts
+++ b/src/integration-tests/Todos_sort_limit.integration.test.ts
@@ -49,6 +49,7 @@ describe("Todos_sort_limit", () => {
   let insertedChildren: InsertedTodoRow[] = [];
   let orderedChildrenAfterSort: InsertedTodoRow[] = [];
   let limitedTodosFromFetch: InsertedTodoRow[] = [];
+  let offsetTodosFromFetch: InsertedTodoRow[] = [];
   let insertedTableName: "Todos" | "todos" | null = null;
   const originalFetch = global.fetch;
 
@@ -159,6 +160,19 @@ describe("Todos_sort_limit", () => {
             : Number(todo.parent_todo),
       sort_index: todo.sort_index,
     }));
+
+    const fetchedWithOffset = await getTodos(true, undefined, 3, 2);
+    offsetTodosFromFetch = fetchedWithOffset.map((todo) => ({
+      id: Number(todo.id),
+      title: todo.title,
+      parent_todo:
+        typeof todo.parent_todo === "number"
+          ? todo.parent_todo
+          : todo.parent_todo === null
+            ? null
+            : Number(todo.parent_todo),
+      sort_index: todo.sort_index,
+    }));
   });
 
   afterAll(async () => {
@@ -212,6 +226,13 @@ describe("Todos_sort_limit", () => {
     expect(limitedTodosFromFetch.map((todo) => todo.title)).toEqual([
       "Todo_sort_limit",
       "Todo_sort_limit_c5",
+      "Todo_sort_limit_c1",
+      "Todo_sort_limit_c2",
+      "Todo_sort_limit_c3",
+    ]);
+
+    expect(offsetTodosFromFetch).toHaveLength(3);
+    expect(offsetTodosFromFetch.map((todo) => todo.title)).toEqual([
       "Todo_sort_limit_c1",
       "Todo_sort_limit_c2",
       "Todo_sort_limit_c3",

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -200,13 +200,24 @@ export async function updateTodoDetails(id: string, title: string, description: 
 }
 
 // Fetch all todos from Supabase
-export async function getTodos(showCompleted: boolean = true, category_id?: string | null, limit?: number): Promise<Todo[]> {
+export async function getTodos(
+  showCompleted: boolean = true,
+  category_id?: string | null,
+  limit?: number,
+  offset: number = 0
+): Promise<Todo[]> {
   const userId = await getAuthenticatedUserId();
+  const effectiveLimit = typeof limit === 'number' && Number.isFinite(limit)
+    ? Math.max(Math.floor(limit), 1)
+    : 50;
+  const effectiveOffset = Number.isFinite(offset) ? Math.max(Math.floor(offset), 0) : 0;
+  // Fetch enough roots to cover offset + limit, then fetch all their
+  // descendants in bulk BFS (one query per tree level, not per root).
+  const ROOT_BATCH_SIZE = Math.max(effectiveOffset + effectiveLimit, 100);
+  const pageEndExclusive = effectiveOffset + effectiveLimit;
 
-  const { data, error } = await runTodosQueryWithFallback((tableName) => {
-    let query = supabase
-      .from(tableName)
-      .select('*')
+  const applySharedTodoFilters = (query: any) => {
+    let nextQuery = query
       .eq('owner_id', userId)
       .is('deleted_timestamp', null)
       .order('completed', { ascending: true })
@@ -214,19 +225,91 @@ export async function getTodos(showCompleted: boolean = true, category_id?: stri
       .order('id', { ascending: true });
 
     if (!showCompleted) {
-      query = query.eq('completed', false);
+      nextQuery = nextQuery.eq('completed', false);
     }
     if (category_id) {
-      query = query.eq('category_id', category_id);
+      nextQuery = nextQuery.eq('category_id', category_id);
     }
 
-    return query;
-  });
+    return nextQuery;
+  };
 
-  if (error) throw error;
-  const allTodos = (data ?? []) as Todo[];
-  const limitedTodos = applyHierarchicalTodoLimit(allTodos, limit);
-  return mapTodosWithDescriptionHtml(limitedTodos);
+  const orderedTodos: Todo[] = [];
+  let rootOffset = 0;
+
+  while (orderedTodos.length < pageEndExclusive) {
+    // Fetch a batch of root todos.
+    const { data: rootData, error: rootError } = await runTodosQueryWithFallback((tableName) =>
+      applySharedTodoFilters(
+        supabase
+          .from(tableName)
+          .select('*')
+          .is('parent_todo', null)
+      ).range(rootOffset, rootOffset + ROOT_BATCH_SIZE - 1)
+    );
+    if (rootError) throw rootError;
+    const roots = (rootData ?? []) as Todo[];
+    if (roots.length === 0) break;
+
+    // BFS: fetch all descendants of this root batch in bulk —
+    // one query per tree level instead of one query per root.
+    const childrenByParent = new Map<string, Todo[]>();
+    let frontier: string[] = roots.map((r) => String(r.id));
+
+    while (frontier.length > 0) {
+      const { data: childData, error: childError } = await runTodosQueryWithFallback((tableName) =>
+        applySharedTodoFilters(
+          supabase.from(tableName).select('*').in('parent_todo', frontier)
+        )
+      );
+      if (childError) throw childError;
+      const children = (childData ?? []) as Todo[];
+      if (children.length === 0) break;
+
+      const nextFrontier: string[] = [];
+      for (const child of children) {
+        const parentId = normalizeComparableId(child.parent_todo);
+        if (!parentId) continue;
+        const siblings = childrenByParent.get(parentId) ?? [];
+        siblings.push(child);
+        childrenByParent.set(parentId, siblings);
+        nextFrontier.push(String(child.id));
+      }
+      frontier = nextFrontier;
+    }
+
+    for (const siblings of childrenByParent.values()) {
+      siblings.sort(compareTodosForDisplayOrder);
+    }
+
+    // Flatten roots + their subtrees in hierarchical display order.
+    const visited = new Set<string>();
+    const flattenSubtree = (parentId: string): void => {
+      const children = childrenByParent.get(parentId) ?? [];
+      for (const child of children) {
+        const id = String(child.id);
+        if (visited.has(id)) continue;
+        visited.add(id);
+        orderedTodos.push(child);
+        flattenSubtree(id);
+      }
+    };
+
+    for (const root of roots) {
+      const id = String(root.id);
+      if (!visited.has(id)) {
+        visited.add(id);
+        orderedTodos.push(root);
+        flattenSubtree(id);
+      }
+    }
+
+    rootOffset += roots.length;
+    if (roots.length < ROOT_BATCH_SIZE) break; // last batch
+  }
+
+  const pagedTodos = orderedTodos.slice(effectiveOffset, pageEndExclusive);
+  return mapTodosWithDescriptionHtml(pagedTodos);
 }
 
 // Create a new todo in Supabase

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -211,9 +211,8 @@ export async function getTodos(
     ? Math.max(Math.floor(limit), 1)
     : 50;
   const effectiveOffset = Number.isFinite(offset) ? Math.max(Math.floor(offset), 0) : 0;
-  // Fetch enough roots to cover offset + limit, then fetch all their
-  // descendants in bulk BFS (one query per tree level, not per root).
-  const ROOT_BATCH_SIZE = Math.max(effectiveOffset + effectiveLimit, 100);
+  // Keep a fixed root batch size so query cost does not grow with deep offsets.
+  const ROOT_BATCH_SIZE = 100;
   const pageEndExclusive = effectiveOffset + effectiveLimit;
 
   const applySharedTodoFilters = (query: any) => {

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -242,6 +242,7 @@ export async function getTodos(
 
   // Keep a fixed root batch size so query cost does not grow with deep offsets.
   const ROOT_BATCH_SIZE = 100;
+  const FRONTIER_CHUNK_SIZE = 200;
 
   const applySharedTodoFilters = (query: any) => {
     let nextQuery = query
@@ -284,13 +285,19 @@ export async function getTodos(
     let frontier: string[] = roots.map((r) => String(r.id));
 
     while (frontier.length > 0) {
-      const { data: childData, error: childError } = await runTodosQueryWithFallback((tableName) =>
-        applySharedTodoFilters(
-          supabase.from(tableName).select('*').in('parent_todo', frontier)
-        )
-      );
-      if (childError) throw childError;
-      const children = (childData ?? []) as Todo[];
+      const children: Todo[] = [];
+
+      for (let chunkStart = 0; chunkStart < frontier.length; chunkStart += FRONTIER_CHUNK_SIZE) {
+        const frontierChunk = frontier.slice(chunkStart, chunkStart + FRONTIER_CHUNK_SIZE);
+        const { data: childData, error: childError } = await runTodosQueryWithFallback((tableName) =>
+          applySharedTodoFilters(
+            supabase.from(tableName).select('*').in('parent_todo', frontierChunk)
+          )
+        );
+        if (childError) throw childError;
+        children.push(...((childData ?? []) as Todo[]));
+      }
+
       if (children.length === 0) break;
 
       const nextFrontier: string[] = [];

--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -211,9 +211,37 @@ export async function getTodos(
     ? Math.max(Math.floor(limit), 1)
     : 50;
   const effectiveOffset = Number.isFinite(offset) ? Math.max(Math.floor(offset), 0) : 0;
+  const pageEndExclusive = effectiveOffset + effectiveLimit;
+
+  // When hiding completed todos, include incomplete children whose completed parents
+  // are filtered out by building pages from the full incomplete set.
+  if (!showCompleted) {
+    const { data, error } = await runTodosQueryWithFallback((tableName) => {
+      let query = supabase
+        .from(tableName)
+        .select('*')
+        .eq('owner_id', userId)
+        .is('deleted_timestamp', null)
+        .eq('completed', false)
+        .order('sort_index', { ascending: true })
+        .order('id', { ascending: true });
+
+      if (category_id) {
+        query = query.eq('category_id', category_id);
+      }
+
+      return query;
+    });
+
+    if (error) throw error;
+    const incompleteTodos = (data ?? []) as Todo[];
+    const hierarchicalWindow = applyHierarchicalTodoLimit(incompleteTodos, pageEndExclusive);
+    const pagedTodos = hierarchicalWindow.slice(effectiveOffset, pageEndExclusive);
+    return mapTodosWithDescriptionHtml(pagedTodos);
+  }
+
   // Keep a fixed root batch size so query cost does not grow with deep offsets.
   const ROOT_BATCH_SIZE = 100;
-  const pageEndExclusive = effectiveOffset + effectiveLimit;
 
   const applySharedTodoFilters = (query: any) => {
     let nextQuery = query


### PR DESCRIPTION
- GET /api/todos: add offset param, return { todos, limit } instead of array
- dataService.getTodos: add offset param, paginate using BFS root batching to preserve hierarchical display order (parent followed by children)
- TodoPageClient: add IntersectionObserver sentinel, loadMore, pageSize/ offset/hasMore/isLoadingMore state
- TodoList: handle both array and { todos } response shapes for showCompleted toggle