### PR TITLE
ix applied

### DIFF
--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -112,13 +112,11 @@ export function applyHierarchicalTodoLimit(todos: Todo[], limit?: number): Todo[
   if (safeLimit === 0) {
     return [];
   }
-  if (todos.length <= safeLimit) {
-    return todos;
-  }
 
   const todoById = new Map<string, Todo>();
   const childrenByParent = new Map<string, Todo[]>();
   const roots: Todo[] = [];
+  const orphanRoots: Todo[] = [];
 
   for (const todo of todos) {
     todoById.set(String(todo.id), todo);
@@ -126,8 +124,13 @@ export function applyHierarchicalTodoLimit(todos: Todo[], limit?: number): Todo[
 
   for (const todo of todos) {
     const parentId = normalizeComparableId(todo.parent_todo);
-    if (!parentId || !todoById.has(parentId)) {
+    if (!parentId) {
       roots.push(todo);
+      continue;
+    }
+
+    if (!todoById.has(parentId)) {
+      orphanRoots.push(todo);
       continue;
     }
 
@@ -137,6 +140,7 @@ export function applyHierarchicalTodoLimit(todos: Todo[], limit?: number): Todo[
   }
 
   roots.sort(compareTodosForDisplayOrder);
+  orphanRoots.sort(compareTodosForDisplayOrder);
   for (const siblings of childrenByParent.values()) {
     siblings.sort(compareTodosForDisplayOrder);
   }
@@ -162,6 +166,11 @@ export function applyHierarchicalTodoLimit(todos: Todo[], limit?: number): Todo[
   for (const root of roots) {
     if (selected.length >= safeLimit) break;
     visit(root);
+  }
+
+  for (const orphanRoot of orphanRoots) {
+    if (selected.length >= safeLimit) break;
+    visit(orphanRoot);
   }
 
   // Safety fallback for any disconnected/cyclic edge cases.

--- a/src/unit-tests/todoHierarchyLimit.test.ts
+++ b/src/unit-tests/todoHierarchyLimit.test.ts
@@ -17,6 +17,18 @@ function todo(overrides: Partial<Todo>): Todo {
 }
 
 describe("applyHierarchicalTodoLimit", () => {
+  it("preserves hierarchical order when limit exceeds todo count", () => {
+    const todos: Todo[] = [
+      todo({ id: "2", sort_index: 1, parent_todo: null, title: "Parent B" }),
+      todo({ id: "3", sort_index: 0, parent_todo: "1", title: "Child of A" }),
+      todo({ id: "1", sort_index: 0, parent_todo: null, title: "Parent A" }),
+    ];
+
+    const limited = applyHierarchicalTodoLimit(todos, 10);
+
+    expect(limited.map((t) => t.id)).toEqual(["1", "3", "2"]);
+  });
+
   it("counts parent and children toward the same limit", () => {
     const todos: Todo[] = [
       todo({ id: "100", sort_index: 0, parent_todo: null, title: "Parent" }),
@@ -42,6 +54,17 @@ describe("applyHierarchicalTodoLimit", () => {
     const limited = applyHierarchicalTodoLimit(todos, 2);
 
     expect(limited.map((t) => t.id)).toEqual(["1", "2"]);
+  });
+
+  it("keeps orphan children after real roots even with a large limit", () => {
+    const todos: Todo[] = [
+      todo({ id: "10", sort_index: 5, parent_todo: null, title: "Root" }),
+      todo({ id: "11", sort_index: 0, parent_todo: "999", title: "Orphan" }),
+    ];
+
+    const limited = applyHierarchicalTodoLimit(todos, 10);
+
+    expect(limited.map((t) => t.id)).toEqual(["10", "11"]);
   });
 
   it("returns all todos when no limit is provided", () => {

--- a/src/unit-tests/todoHierarchyLimit.test.ts
+++ b/src/unit-tests/todoHierarchyLimit.test.ts
@@ -44,7 +44,7 @@ describe("applyHierarchicalTodoLimit", () => {
     expect(limited.map((t) => t.id)).toEqual(["100", "101", "102", "103", "104"]);
   });
 
-  it("does not return orphan children before available roots", () => {
+  it("does not return orphan roots before available roots", () => {
     const todos: Todo[] = [
       todo({ id: "1", sort_index: 0, parent_todo: null, title: "Parent A" }),
       todo({ id: "2", sort_index: 0, parent_todo: null, title: "Parent B" }),
@@ -56,7 +56,7 @@ describe("applyHierarchicalTodoLimit", () => {
     expect(limited.map((t) => t.id)).toEqual(["1", "2"]);
   });
 
-  it("keeps orphan children after real roots even with a large limit", () => {
+  it("keeps orphan roots after real roots even with a large limit", () => {
     const todos: Todo[] = [
       todo({ id: "10", sort_index: 5, parent_todo: null, title: "Root" }),
       todo({ id: "11", sort_index: 0, parent_todo: "999", title: "Orphan" }),


### PR DESCRIPTION
In dataService.ts, I changed applyHierarchicalTodoLimit to: Keep real roots (parent_todo = null) separate from orphan roots (parent_todo points to a missing parent in the current filtered dataset). Traverse all real roots first.
Only then append orphan roots.
I kept the previous correction that always rebuilds hierarchical order even when limit is larger than the current list size. Tests added/updated
In todoHierarchyLimit.test.ts, I added:

A test that ensures hierarchy is preserved even when limit exceeds todo count. A test that ensures orphan children stay after real roots even with a large limit.